### PR TITLE
fix: Prevent duplicate requests

### DIFF
--- a/projects/client/package.json
+++ b/projects/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buoy/client",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A GraphQL client for Angular built on top of Apollo.",
   "author": "Albert Haff <ahn@haffdata.com>",
   "license": "MIT",


### PR DESCRIPTION
Prevent duplicate requests when initialising a watch query